### PR TITLE
CodeQL scan 1558: Use of insecure SSL/TLS version

### DIFF
--- a/crypto/krb5/src/util/wsgiref-kdcproxy.py
+++ b/crypto/krb5/src/util/wsgiref-kdcproxy.py
@@ -15,6 +15,12 @@ else:
 
 server = make_server('localhost', port, kdcproxy.Application())
 sslctx = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+# Restrict to TLSv1.2 and higher
+try:
+    sslctx.minimum_version = ssl.TLSVersion.TLSv1_2
+except AttributeError:
+    # For Python versions < 3.7, set protocol options manually
+    sslctx.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
 sslctx.load_cert_chain(certfile=pem)
 server.socket = sslctx.wrap_socket(server.socket, server_side=True)
 os.write(sys.stdout.fileno(), b'proxy server ready\n')


### PR DESCRIPTION
CodeQL scan 1558 [https://github.com/rcghpge/freebsd/security/code-scanning/1558](https://github.com/rcghpge/freebsd/security/code-scanning/1558)

SSL/TLS protocol versioning. See MITRE [CWE-327](https://cwe.mitre.org/data/definitions/327.html).

Push to dev branch

---
